### PR TITLE
Исправить ошибку получения errorMessages в форме без label

### DIFF
--- a/HTML/QuickForm2.php
+++ b/HTML/QuickForm2.php
@@ -256,8 +256,9 @@ class HTML_QuickForm2 extends HTML_QuickForm2_Container
             if (!$elem->getError()) {
                 continue;
             }
-            $label = $elem->getData()['label'];
-            $label = is_array($label) ? $label[0] : $label;
+            $elementData = $elem->getData();
+            $label       = is_array($elementData) && array_key_exists('label', $elementData) ? $elementData['label'] : '';
+            $label       = is_array($label) ? $label[0] : $label;
             if ($label) {
                 $error_messages[] = sprintf('%s: %s', $label, $elem->getError());
             } else {


### PR DESCRIPTION
### Задачи Asana
https://app.asana.com/0/534203904994086/1209147915285560/f

### Информация
Для открытия модалки с формой при перезагрузке страницы с ошибкой в форме используем errorMessages. Получили не понятную ошибку при использовании. Оказалось, что метод не работает при не установленных label. Лучше исправить в  HTML_QuickForm2, чем во всех формах добавлять ненужные label.

![Снимок экрана от 2025-01-17 17-08-25](https://github.com/user-attachments/assets/cf029418-6a0e-4422-be06-f8c6434afda3)

